### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/DockingFeature/DockingDlgInterface.h
+++ b/DockingFeature/DockingDlgInterface.h
@@ -41,7 +41,7 @@ public:
 
     void create(tTbData * data, bool isRTL = false){
 		StaticDialog::create(_dlgID, isRTL);
-		::GetWindowText(_hSelf, _pluginName, sizeof(_pluginName));
+		::GetWindowText(_hSelf, _pluginName, sizeof(_pluginName)/sizeof(TCHAR));
 
         // user information
 		data->hClient		= _hSelf;

--- a/globals.cpp
+++ b/globals.cpp
@@ -97,6 +97,8 @@ wstring GetPythonPath() {
 				pythonInstalled = true;
 				break;
 			}
+
+			delete[] nPtr;
 		} while (FindNextFile(h, &data));
 	}
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V575](https://www.viva64.com/en/w/v575/) The number of processed elements should be passed to the 'GetWindowTextW' function as the third argument instead of buffer's size in bytes. dockingdlginterface.h 44
[V773](https://www.viva64.com/en/w/v773/) Visibility scope of the 'nPtr' pointer was exited without releasing the memory. A memory leak is possible. globals.cpp 100